### PR TITLE
Remove moment as a dependency

### DIFF
--- a/format.js
+++ b/format.js
@@ -9,7 +9,7 @@ const util = require('util');
  * @returns A two-digit number
  * @throws {TypeError} if the provided value is not a valid integer
  */
-function formatTwoDigits(number) {
+function toTwoDigits(number) {
   if (!Number.isInteger(number)) {
     throw new TypeError(`Not a valid integer: ${number}`);
   }
@@ -26,7 +26,7 @@ function formatTwoDigits(number) {
  * @returns {string}
  * @throws {TypeError} if the provided value is not a valid month number
  */
-function formatShortMonth(month) {
+function toShortMonth(month) {
   switch (month) {
     // Note: January is month 0!
     case 0:
@@ -65,14 +65,14 @@ function formatShortMonth(month) {
  * @returns {string}
  * @throws {TypeError} if the provided value is not a valid integer
  */
-function formatOffset(offsetMinutes) {
+function toOffset(offsetMinutes) {
   if (!Number.isInteger(offsetMinutes)) {
     throw new TypeError(`Not a valid integer: ${offsetMinutes}`);
   }
 
   const absoluteOffset = Math.abs(offsetMinutes);
-  const hours = formatTwoDigits(Math.floor(absoluteOffset / 60));
-  const minutes = formatTwoDigits(absoluteOffset % 60);
+  const hours = toTwoDigits(Math.floor(absoluteOffset / 60));
+  const minutes = toTwoDigits(absoluteOffset % 60);
   const sign = offsetMinutes >= 0 ? '-' : '+';
 
   return `${sign}${hours}${minutes}`;
@@ -85,7 +85,7 @@ function formatOffset(offsetMinutes) {
  * @param {Date} date
  * @returns {string}
  */
-function formatCommonAccessLogDate(date) {
+function toCommonAccessLogDateFormat(date) {
   if (!(date instanceof Date)) {
     throw new TypeError('Not a valid date');
   }
@@ -93,19 +93,19 @@ function formatCommonAccessLogDate(date) {
   // e.g: 10/Oct/2000:13:55:36 -0700
   return util.format(
     '%s/%s/%s:%s:%s:%s %s',
-    formatTwoDigits(date.getDate()),
-    formatShortMonth(date.getMonth()),
+    toTwoDigits(date.getDate()),
+    toShortMonth(date.getMonth()),
     date.getFullYear(),
-    formatTwoDigits(date.getHours()),
-    formatTwoDigits(date.getMinutes()),
-    formatTwoDigits(date.getSeconds()),
-    formatOffset(date.getTimezoneOffset())
+    toTwoDigits(date.getHours()),
+    toTwoDigits(date.getMinutes()),
+    toTwoDigits(date.getSeconds()),
+    toOffset(date.getTimezoneOffset())
   );
 }
 
 module.exports = {
-  formatCommonAccessLogDate,
-  formatOffset,
-  formatShortMonth,
-  formatTwoDigits
+  toCommonAccessLogDateFormat,
+  toOffset,
+  toShortMonth,
+  toTwoDigits
 };

--- a/format.js
+++ b/format.js
@@ -18,42 +18,39 @@ function toTwoDigits(number) {
 }
 
 /**
+ * Look-up map of month number into month short name (in english).
+ * A month number is the value returned by Date#getMonth() and a short month name
+ * is a 3 letter representation of a month of the year.
+ */
+const shortMonthByMonthNumber = {
+  0: 'Jan',
+  1: 'Feb',
+  2: 'Mar',
+  3: 'Apr',
+  4: 'May',
+  5: 'Jun',
+  6: 'Jul',
+  7: 'Aug',
+  8: 'Sep',
+  9: 'Oct',
+  10: 'Nov',
+  11: 'Dec'
+};
+
+/**
  * Returns a [short](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#month)
  * (3-letters) representation of the given month index **in English**.
+ *
  * @param {number} month
  * @returns {string}
  * @throws {TypeError} if the provided value is not a valid month number
  */
 function toShortMonth(month) {
-  switch (month) {
-    // Note: January is month 0!
-    case 0:
-      return 'Jan';
-    case 1:
-      return 'Feb';
-    case 2:
-      return 'Mar';
-    case 3:
-      return 'Apr';
-    case 4:
-      return 'May';
-    case 5:
-      return 'Jun';
-    case 6:
-      return 'Jul';
-    case 7:
-      return 'Aug';
-    case 8:
-      return 'Sep';
-    case 9:
-      return 'Oct';
-    case 10:
-      return 'Nov';
-    case 11:
-      return 'Dec';
-    default:
-      throw new TypeError(`Not a valid month value: ${month}`);
+  if (month in shortMonthByMonthNumber) {
+    throw new TypeError(`Not a valid month value: ${month}`);
   }
+
+  return shortMonthByMonthNumber[month];
 }
 
 /**

--- a/format.js
+++ b/format.js
@@ -14,9 +14,7 @@ function toTwoDigits(number) {
     throw new TypeError(`Not a valid integer: ${number}`);
   }
 
-  const n = String(number);
-
-  return n.padStart(2, '0');
+  return number.toString().padStart(2, '0');
 }
 
 /**

--- a/format.js
+++ b/format.js
@@ -46,7 +46,7 @@ const shortMonthByMonthNumber = {
  * @throws {TypeError} if the provided value is not a valid month number
  */
 function toShortMonth(month) {
-  if (month in shortMonthByMonthNumber) {
+  if (!(month in shortMonthByMonthNumber)) {
     throw new TypeError(`Not a valid month value: ${month}`);
   }
 

--- a/format.js
+++ b/format.js
@@ -1,0 +1,111 @@
+const util = require('util');
+
+/**
+ * Pads the provided number into a string of 2 digits; adding leading
+ * zeros if needed.
+ * Values resulting in more than 2 digits are left untouched.
+ *
+ * @param {string} number
+ * @returns A two-digit number
+ * @throws {TypeError} if the provided value is not a valid integer
+ */
+function formatTwoDigits(number) {
+  if (!Number.isInteger(number)) {
+    throw new TypeError(`Not a valid integer: ${number}`);
+  }
+
+  const n = String(number);
+
+  return n.padStart(2, '0');
+}
+
+/**
+ * Returns a [short](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#month)
+ * (3-letters) representation of the given month index **in English**.
+ * @param {number} month
+ * @returns {string}
+ * @throws {TypeError} if the provided value is not a valid month number
+ */
+function formatShortMonth(month) {
+  switch (month) {
+    // Note: January is month 0!
+    case 0:
+      return 'Jan';
+    case 1:
+      return 'Feb';
+    case 2:
+      return 'Mar';
+    case 3:
+      return 'Apr';
+    case 4:
+      return 'May';
+    case 5:
+      return 'Jun';
+    case 6:
+      return 'Jul';
+    case 7:
+      return 'Aug';
+    case 8:
+      return 'Sep';
+    case 9:
+      return 'Oct';
+    case 10:
+      return 'Nov';
+    case 11:
+      return 'Dec';
+    default:
+      throw new TypeError(`Not a valid month value: ${month}`);
+  }
+}
+
+/**
+ * Returns a [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant
+ * offset string.
+ *
+ * @returns {string}
+ * @throws {TypeError} if the provided value is not a valid integer
+ */
+function formatOffset(offsetMinutes) {
+  if (!Number.isInteger(offsetMinutes)) {
+    throw new TypeError(`Not a valid integer: ${offsetMinutes}`);
+  }
+
+  const absoluteOffset = Math.abs(offsetMinutes);
+  const hours = formatTwoDigits(Math.floor(absoluteOffset / 60));
+  const minutes = formatTwoDigits(absoluteOffset % 60);
+  const sign = offsetMinutes >= 0 ? '-' : '+';
+
+  return `${sign}${hours}${minutes}`;
+}
+
+/**
+ * Formats the provided date into a [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format)
+ * compliant string.
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatCommonAccessLogDate(date) {
+  if (!(date instanceof Date)) {
+    throw new TypeError('Not a valid date');
+  }
+
+  // e.g: 10/Oct/2000:13:55:36 -0700
+  return util.format(
+    '%s/%s/%s:%s:%s:%s %s',
+    formatTwoDigits(date.getDate()),
+    formatShortMonth(date.getMonth()),
+    date.getFullYear(),
+    formatTwoDigits(date.getHours()),
+    formatTwoDigits(date.getMinutes()),
+    formatTwoDigits(date.getSeconds()),
+    formatOffset(date.getTimezoneOffset())
+  );
+}
+
+module.exports = {
+  formatCommonAccessLogDate,
+  formatOffset,
+  formatShortMonth,
+  formatTwoDigits
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const util = require('util');
-const { formatCommonAccessLogDate } = require('./format');
+const { toCommonAccessLogDateFormat } = require('./format');
 
 module.exports = function (stream) {
   if (!stream) stream = process.stdout;
@@ -13,7 +13,7 @@ module.exports = function (stream) {
 
     // eslint-disable-next-line unicorn/explicit-length-check
     const length = ctx.length ? ctx.length.toString() : '-';
-    const date = formatCommonAccessLogDate(new Date());
+    const date = toCommonAccessLogDateFormat(new Date());
 
     stream.write(
       util.format(

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const util = require('util');
-const moment = require('moment');
+const { formatCommonAccessLogDate } = require('./format');
 
 module.exports = function (stream) {
   if (!stream) stream = process.stdout;
@@ -13,7 +13,7 @@ module.exports = function (stream) {
 
     // eslint-disable-next-line unicorn/explicit-length-check
     const length = ctx.length ? ctx.length.toString() : '-';
-    const date = moment().format('D/MMM/YYYY:HH:mm:ss ZZ');
+    const date = formatCommonAccessLogDate(new Date());
 
     stream.write(
       util.format(

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "3imed-jaberi <imed_jebari@hotmail.fr> (https://www.3imed-jaberi.com)"
   ],
   "license": "MIT",
-  "dependencies": {
-    "moment": "^2.26.0"
-  },
   "devDependencies": {
     "eslint-config-xo-lass": "^1.0.3",
     "koa": "^2.12.1",

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -1,0 +1,95 @@
+const {
+  formatCommonAccessLogDate,
+  formatOffset,
+  formatShortMonth,
+  formatTwoDigits,
+} = require('../format')
+
+describe('formatTwoDigits', () => {
+  test.each([
+    { value: 0, expected: '00' },
+    { value: 1, expected: '01' },
+    { value: 11, expected: '11' },
+    { value: 99, expected: '99' },
+    { value: 123, expected: '123' },
+  ])('returns $expected for $value', ({ value, expected }) => {
+    expect(formatTwoDigits(value)).toBe(expected)
+  })
+
+  test('throws TypeError if provided value is Infinity', () => {
+    expect(() => formatTwoDigits(Infinity)).toThrow(TypeError)
+  })
+
+  test('throws TypeError if provided value is NaN', () => {
+    expect(() => formatTwoDigits(NaN)).toThrow(TypeError)
+  })
+
+  test('throws TypeError if provided value is a decimal number', () => {
+    expect(() => formatTwoDigits(0.99)).toThrow(TypeError)
+  })
+
+  test('throws TypeError if provided value is a string', () => {
+    expect(() => formatTwoDigits('0')).toThrow(TypeError)
+  })
+})
+
+describe('formatOffset', () => {
+  test.each([
+    { value: 480, expected: '-0800' },
+    { value: 0, expected: '+0000' },
+    { value: -180, expected: '+0300' },
+  ])('returns $expected for $value', ({ value, expected }) => {
+    expect(formatOffset(value)).toBe(expected)
+  })
+
+  test('throws TypeError if provided value is Infinity', () => {
+    expect(() => formatOffset(Infinity)).toThrow(TypeError)
+  })
+
+  test('throws TypeError if provided value is NaN', () => {
+    expect(() => formatOffset(NaN)).toThrow(TypeError)
+  })
+
+  test('throws TypeError if provided value is a decimal number', () => {
+    expect(() => formatOffset(60.5)).toThrow(TypeError)
+  })
+
+  test('throws TypeError if provided value is a string', () => {
+    expect(() => formatOffset('60')).toThrow(TypeError)
+  })
+})
+
+describe('formatShortMonth', () => {
+  test.each([
+    { value: 0, expected: 'Jan' },
+    { value: 1, expected: 'Feb' },
+    { value: 2, expected: 'Mar' },
+    { value: 3, expected: 'Apr' },
+    { value: 4, expected: 'May' },
+    { value: 5, expected: 'Jun' },
+    { value: 6, expected: 'Jul' },
+    { value: 7, expected: 'Aug' },
+    { value: 8, expected: 'Sep' },
+    { value: 9, expected: 'Oct' },
+    { value: 10, expected: 'Nov' },
+    { value: 11, expected: 'Dec' },
+  ])('returns $expected for $value', ({ value, expected }) => {
+    expect(formatShortMonth(value)).toBe(expected)
+  })
+
+  test('throws TypeError for a non-valid month number', () => {
+    expect(() => formatShortMonth(13)).toThrow(TypeError)
+  })
+})
+
+describe('formatCommonAccessLogDate', () => {
+  test('correctly formats a date', () => {
+    const date = new Date('2020-01-01T12:34:56Z')
+    const expectedValue = '01/Jan/2020:10:34:56 +0200'
+    expect(formatCommonAccessLogDate(date)).toBe(expectedValue)
+  })
+
+  test('throws TypeError for non-Date value', () => {
+    expect(() => formatCommonAccessLogDate({})).toThrow(TypeError)
+  })
+})

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -1,11 +1,11 @@
 const {
-  formatCommonAccessLogDate,
-  formatOffset,
-  formatShortMonth,
-  formatTwoDigits,
+  toCommonAccessLogDateFormat,
+  toOffset,
+  toShortMonth,
+  toTwoDigits,
 } = require('../format')
 
-describe('formatTwoDigits', () => {
+describe('toTwoDigits', () => {
   test.each([
     { value: 0, expected: '00' },
     { value: 1, expected: '01' },
@@ -13,53 +13,53 @@ describe('formatTwoDigits', () => {
     { value: 99, expected: '99' },
     { value: 123, expected: '123' },
   ])('returns $expected for $value', ({ value, expected }) => {
-    expect(formatTwoDigits(value)).toBe(expected)
+    expect(toTwoDigits(value)).toBe(expected)
   })
 
   test('throws TypeError if provided value is Infinity', () => {
-    expect(() => formatTwoDigits(Infinity)).toThrow(TypeError)
+    expect(() => toTwoDigits(Infinity)).toThrow(TypeError)
   })
 
   test('throws TypeError if provided value is NaN', () => {
-    expect(() => formatTwoDigits(NaN)).toThrow(TypeError)
+    expect(() => toTwoDigits(NaN)).toThrow(TypeError)
   })
 
   test('throws TypeError if provided value is a decimal number', () => {
-    expect(() => formatTwoDigits(0.99)).toThrow(TypeError)
+    expect(() => toTwoDigits(0.99)).toThrow(TypeError)
   })
 
   test('throws TypeError if provided value is a string', () => {
-    expect(() => formatTwoDigits('0')).toThrow(TypeError)
+    expect(() => toTwoDigits('0')).toThrow(TypeError)
   })
 })
 
-describe('formatOffset', () => {
+describe('toOffset', () => {
   test.each([
     { value: 480, expected: '-0800' },
     { value: 0, expected: '+0000' },
     { value: -180, expected: '+0300' },
   ])('returns $expected for $value', ({ value, expected }) => {
-    expect(formatOffset(value)).toBe(expected)
+    expect(toOffset(value)).toBe(expected)
   })
 
   test('throws TypeError if provided value is Infinity', () => {
-    expect(() => formatOffset(Infinity)).toThrow(TypeError)
+    expect(() => toOffset(Infinity)).toThrow(TypeError)
   })
 
   test('throws TypeError if provided value is NaN', () => {
-    expect(() => formatOffset(NaN)).toThrow(TypeError)
+    expect(() => toOffset(NaN)).toThrow(TypeError)
   })
 
   test('throws TypeError if provided value is a decimal number', () => {
-    expect(() => formatOffset(60.5)).toThrow(TypeError)
+    expect(() => toOffset(60.5)).toThrow(TypeError)
   })
 
   test('throws TypeError if provided value is a string', () => {
-    expect(() => formatOffset('60')).toThrow(TypeError)
+    expect(() => toOffset('60')).toThrow(TypeError)
   })
 })
 
-describe('formatShortMonth', () => {
+describe('toShortMonth', () => {
   test.each([
     { value: 0, expected: 'Jan' },
     { value: 1, expected: 'Feb' },
@@ -74,22 +74,22 @@ describe('formatShortMonth', () => {
     { value: 10, expected: 'Nov' },
     { value: 11, expected: 'Dec' },
   ])('returns $expected for $value', ({ value, expected }) => {
-    expect(formatShortMonth(value)).toBe(expected)
+    expect(toShortMonth(value)).toBe(expected)
   })
 
   test('throws TypeError for a non-valid month number', () => {
-    expect(() => formatShortMonth(13)).toThrow(TypeError)
+    expect(() => toShortMonth(13)).toThrow(TypeError)
   })
 })
 
-describe('formatCommonAccessLogDate', () => {
+describe('toCommonAccessLogDateFormat', () => {
   test('correctly formats a date', () => {
     const date = new Date('2020-01-01T12:34:56Z')
     const expectedValue = '01/Jan/2020:10:34:56 +0200'
-    expect(formatCommonAccessLogDate(date)).toBe(expectedValue)
+    expect(toCommonAccessLogDateFormat(date)).toBe(expectedValue)
   })
 
   test('throws TypeError for non-Date value', () => {
-    expect(() => formatCommonAccessLogDate({})).toThrow(TypeError)
+    expect(() => toCommonAccessLogDateFormat({})).toThrow(TypeError)
   })
 })


### PR DESCRIPTION
For as simple as this `koa-accesslog` is; bringing moment into the dependency tree just to format a date felt a bit overkill.

This PR replaces moment with a local minimal implementation **only with en support**.

## Why not using Intl?
[Intl](https://nodejs.org/docs/latest-v18.x/api/intl.html) availability on runtime depends on how the node binary was built and how the process running was started (you can read more [here](https://nodejs.org/docs/latest-v18.x/api/intl.html#options-for-building-nodejs)). Since I did not want to couple the library to a specific icu setup; I decided to implement the minimal required code for the date formatting needs of the library.

## Would this be a breaking change?
To be honest: I'm not 100% sure. I have tried to keep the implementation as close as possible to what we had; but this PR would change how the short month is rendered for non-en configured systems. Not a big deal; but worht considering when decieding.

It is also worth noting this PR is indepentent from #10 but they would create a conflict with eachother because of the changes in the `package-lock.json` in the other PR.
